### PR TITLE
モデルの色設定機能追加とライティング計算修正

### DIFF
--- a/project/Resources/Shaders/Object3d.PS.hlsl
+++ b/project/Resources/Shaders/Object3d.PS.hlsl
@@ -41,13 +41,13 @@ PixcelShaderOutput main(VertexShaderOutPut input)
     
     if (gMaterial.enableLighting != 0)
     {
-        float NdotL = dot(normalize(input.normal), normalize(-gDirectionalLight.direction));
+        float NdotL = dot(normalize(input.normal), -gDirectionalLight.direction);
         float cos = pow(NdotL * 0.5f + 0.5f, 2.0f);
       
       // output.color = gMaterial.color * textureColor * gDirectionalLight.color * cos * gDirectionalLight.intensity;
        
-        
-        output.color.rgb = gMaterial.color.rgb * textureColor.rgb * gDirectionalLight.color.rgb * cos * gDirectionalLight.intensity;
+       
+            output.color.rgb = gMaterial.color.rgb * textureColor.rgb * gDirectionalLight.color.rgb * cos * gDirectionalLight.intensity;
         output.color.a = gMaterial.color.a * textureColor.a;
         
     }
@@ -58,6 +58,18 @@ PixcelShaderOutput main(VertexShaderOutPut input)
     }
     
     
+    if (textureColor.a <= 0.5f)
+    {
+        discard;
+    }
+    if (textureColor.a == 0.0f)
+    {
+        discard;
+    }
+    if (output.color.a == 0.0f)
+    {
+        discard;
+    }
   
     
     return output;

--- a/project/engine/graphic/3d/Model.h
+++ b/project/engine/graphic/3d/Model.h
@@ -45,6 +45,13 @@ public:
 	static ModelData LoadObjFile(const std::string& directoryPath, const std::string& filename);
 
 
+	void SetModelColor(const Vector4& color) {
+		materialData->color = color;
+	}
+
+	Vector4 GetModelColor() {
+		return materialData->color;
+	}
 	
 private:
 	//共通部分

--- a/project/engine/graphic/3d/Object3d.cpp
+++ b/project/engine/graphic/3d/Object3d.cpp
@@ -115,3 +115,13 @@ void Object3d::SetModel(const std::string& filePath)
 	model_ = ModelManager::GetInstance()->FindModel(filePath);
 }
 
+void Object3d::SetModelColor(const Vector4& color)
+{
+	model_->SetModelColor(color);
+}
+
+Vector4 Object3d::GetModelColor()
+{
+	return model_->GetModelColor();
+}
+

--- a/project/engine/graphic/3d/Object3d.h
+++ b/project/engine/graphic/3d/Object3d.h
@@ -64,11 +64,14 @@ public:
 	void SetModel(const std::string& filePath);
 	void SetCamera(Camera* camera) { this->camera = camera; }
 
+	void SetModelColor(const Vector4& color);
+
 	//Getter
 	Vector3 GetScale() const { return transform.scale; }
 	Vector3 GetRotation() const { return transform.rotate; }
 	Vector3 GetPosition() const { return transform.translate; }
 
+	Vector4 GetModelColor();
 
 
 private:

--- a/project/engine/graphic/PSO.cpp
+++ b/project/engine/graphic/PSO.cpp
@@ -147,9 +147,45 @@ void PSO::CreateGraphicPipeline()
 	blendDesc.RenderTarget[0].RenderTargetWriteMask =
 		D3D12_COLOR_WRITE_ENABLE_ALL;
 	blendDesc.RenderTarget[0].BlendEnable = TRUE;
-	blendDesc.RenderTarget[0].SrcBlend = D3D12_BLEND_SRC_ALPHA; // provided code
-	blendDesc.RenderTarget[0].BlendOp = D3D12_BLEND_OP_ADD;
-	blendDesc.RenderTarget[0].DestBlend = D3D12_BLEND_INV_SRC_ALPHA;
+	switch (blendMode)
+	{
+	case PSO::kBlendModeNone:
+		blendDesc.RenderTarget[0].SrcBlend = D3D12_BLEND_ONE;
+		blendDesc.RenderTarget[0].BlendOp = D3D12_BLEND_OP_ADD;
+		blendDesc.RenderTarget[0].DestBlend = D3D12_BLEND_ZERO;
+		break;
+	case PSO::kBlendModeNormal:
+		blendDesc.RenderTarget[0].SrcBlend = D3D12_BLEND_SRC_ALPHA; // provided code
+		blendDesc.RenderTarget[0].BlendOp = D3D12_BLEND_OP_ADD;
+		blendDesc.RenderTarget[0].DestBlend = D3D12_BLEND_INV_SRC_ALPHA;
+		break;
+	case PSO::kBlendModeAdd:
+		blendDesc.RenderTarget[0].SrcBlend = D3D12_BLEND_SRC_ALPHA; // provided code
+		blendDesc.RenderTarget[0].BlendOp = D3D12_BLEND_OP_ADD;
+		blendDesc.RenderTarget[0].DestBlend = D3D12_BLEND_ONE;
+		break;
+	case PSO::kBlendModeSubtract:
+		blendDesc.RenderTarget[0].SrcBlend = D3D12_BLEND_SRC_ALPHA; // provided code
+		blendDesc.RenderTarget[0].BlendOp = D3D12_BLEND_OP_REV_SUBTRACT;
+		blendDesc.RenderTarget[0].DestBlend = D3D12_BLEND_ONE;
+		break;
+	case PSO::kBlendModeMultily:
+		blendDesc.RenderTarget[0].SrcBlend = D3D12_BLEND_ZERO;
+		blendDesc.RenderTarget[0].BlendOp = D3D12_BLEND_OP_ADD;
+		blendDesc.RenderTarget[0].DestBlend = D3D12_BLEND_SRC_COLOR;
+		break;
+	case PSO::kBlendModeScreen:
+		blendDesc.RenderTarget[0].SrcBlend = D3D12_BLEND_INV_DEST_COLOR;
+		blendDesc.RenderTarget[0].BlendOp = D3D12_BLEND_OP_ADD;
+		blendDesc.RenderTarget[0].DestBlend = D3D12_BLEND_ONE;
+		break;
+	case PSO::kCountBlendMode:
+		break;
+	default:
+		break;
+	}
+	
+
 	blendDesc.RenderTarget[0].SrcBlendAlpha = D3D12_BLEND_ONE;
 	blendDesc.RenderTarget[0].BlendOpAlpha = D3D12_BLEND_OP_ADD;
 	blendDesc.RenderTarget[0].DestBlendAlpha = D3D12_BLEND_ZERO;

--- a/project/engine/graphic/PSO.h
+++ b/project/engine/graphic/PSO.h
@@ -2,7 +2,25 @@
 #include"DirectXCommon.h"
 class PSO
 {
-
+private:
+	//ブレンドモード
+	enum BlendMode
+	{
+		//!<ブレンドなし
+		kBlendModeNone,
+		//!<通常アルファブレンド
+		kBlendModeNormal,
+		//!<加算アルファブレンド
+		kBlendModeAdd,
+		//!<減算アルファブレンド
+		kBlendModeSubtract,
+		//!<乗算アルファブレンド
+		kBlendModeMultily,
+		//!<スクリーン
+		kBlendModeScreen,
+		//利用してはいけない
+		kCountBlendMode,
+	};
 
 public:
 	/// <summary>
@@ -15,6 +33,18 @@ public:
 	/// 共通描画設定
 	/// </summary>
 	void DrawSettingsCommon();
+
+public:
+	/// <summary>
+	/// ブレンドモードの設定
+	/// </summary>
+	/// <param name="blendMode">ブレンドモード</param>
+	void SetBlendMode(BlendMode blendMode) { this->blendMode = blendMode; }
+	/// <summary>
+	/// ブレンドモードの取得
+	/// </summary>
+	/// <returns>ブレンドモード</returns>
+	BlendMode GetBlendMode()const { return blendMode; }
 
 private:
 	/*---------------------------------------------------
@@ -87,7 +117,7 @@ private:
 	Microsoft::WRL::ComPtr <ID3D12GraphicsCommandList> commandList;
 
 
-
+	BlendMode blendMode = kBlendModeNone;
 
 };
 

--- a/project/engine/scene/DebugScene.cpp
+++ b/project/engine/scene/DebugScene.cpp
@@ -210,94 +210,101 @@ void DebugScene::SpriteDraw()
 
 void DebugScene::ImGuiDraw()
 {
-	ImGui::Begin("DebugScene");
-	ImGui::Text("Hello, DebugScene!");
-	ImGui::End();
-
+    ImGui::Begin("DebugScene");
+    ImGui::Text("Hello, DebugScene!");
+    ImGui::End();
 
 #ifdef _DEBUG
 
+    ImGui::Begin("camera");
+    ImGui::DragFloat3("Position", &cameraPosition.x);
+    ImGui::DragFloat3("Rotation", &cameraRotation.x);
+    ImGui::DragFloat3("Scale", &cameraScale.x);
+    ImGui::End();
 
+    //スプライトのImGui
+    for (Sprite* sprite : sprites) {
+        if (sprite) {
+            ImGui::Begin("Sprite");
+            
 
-	ImGui::Begin("camera");
-	ImGui::DragFloat3("Position", &cameraPosition.x);
-	ImGui::DragFloat3("Rotation", &cameraRotation.x);
-	ImGui::DragFloat3("Scale", &cameraScale.x);
-	ImGui::End();
+            Vector2 spritePosition = sprite->GetPosition();
+            ImGui::SliderFloat2("Position", &spritePosition.x, 0.0f, 1920.0f, "%.1f");
+            sprite->SetPosition(spritePosition);
 
-	//スプライトのImGui
-	 //スプライトのImGui
-	for (Sprite* sprite : sprites) {
-		if (sprite) {
-			ImGui::Begin("Sprite");
-			ImGui::SetWindowSize({ 500,100 });
+            ImGui::Checkbox("isFlipX", &isFlipX_);
+            ImGui::Checkbox("isFlipY", &isFlipY_);
+            ImGui::Checkbox("isAdjustTextureSize", &isAdjustTextureSize);
+            ImGui::DragFloat2("textureLeftTop", &textureLeftTop.x);
+			
+			Vector4 color = sprite->GetColor();
+			ImGui::ColorEdit4("Color", &color.x);
+			sprite->SetColor(color);
 
-			Vector2 spritePosition = sprite->GetPosition();
-			ImGui::SliderFloat2("Position", &spritePosition.x, 0.0f, 1920.0f, "%.1f");
-			sprite->SetPosition(spritePosition);
+            ImGui::End();
+        }
+    }
+    ImGui::Begin("Object3D");
+    ImGui::DragFloat3("Position", &modelPosition.x);
+    ImGui::DragFloat3("Rotation", &modelRotation.x);
+    ImGui::DragFloat3("Scale", &modelScale.x);
 
-			ImGui::Checkbox("isFlipX", &isFlipX_);
-			ImGui::Checkbox("isFlipY", &isFlipY_);
-			ImGui::Checkbox("isAdjustTextureSize", &isAdjustTextureSize);
-			ImGui::DragFloat2("textureLeftTop", &textureLeftTop.x);
+    Vector4 color = object3d->GetModelColor();
+    ImGui::ColorEdit4("Color", &color.x);
+    object3d->SetModelColor(color);
 
-			ImGui::End();
-		}
-	}
-	ImGui::Begin("Object3D");
-	ImGui::DragFloat3("Position", &modelPosition.x);
-	ImGui::DragFloat3("Rotation", &modelRotation.x);
-	ImGui::DragFloat3("Scale", &modelScale.x);
-	ImGui::End();
+    ImGui::End();
 
-	ImGui::Begin("Object3D2");
-	ImGui::DragFloat3("Position", &modelPosition2.x);
-	ImGui::DragFloat3("Rotation", &modelRotation2.x);
-	ImGui::DragFloat3("Scale", &modelScale2.x);
-	ImGui::End();
+    ImGui::Begin("Object3D2");
+    ImGui::DragFloat3("Position", &modelPosition2.x);
+    ImGui::DragFloat3("Rotation", &modelRotation2.x);
+    ImGui::DragFloat3("Scale", &modelScale2.x);
 
+	Vector4 color2 = object3d2->GetModelColor();
+	ImGui::ColorEdit4("Color", &color2.x);
+	object3d2->SetModelColor(color2);
 
-	static float scratchPosition = 0.0f;
-	static bool isScratching = false;
-	static float lastScratchPosition = 0.0f;
-	//再生時間
-	float duration = audio->GetSoundDuration();
+    ImGui::End();
 
+    static float scratchPosition = 0.0f;
+    static bool isScratching = false;
+    static float lastScratchPosition = 0.0f;
+    //再生時間
+    float duration = audio->GetSoundDuration();
 
-	ImGui::Begin("Audio Control");
+    ImGui::Begin("Audio Control");
 
-	if (ImGui::Button("Play")) {
-		audio->Play(false);
-	}
-	if (ImGui::Button("Stop")) {
-		audio->Stop();
-	}
-	if (ImGui::Button("Pause")) {
-		audio->Pause();
-	}
-	if (ImGui::Button("Resume")) {
-		audio->Resume();
-	}
-	//volume
-	static float volume = 0.1f;
-	ImGui::SliderFloat("Volume", &volume, 0.0f, 1.0f);
-	audio->SetVolume(volume);
+    if (ImGui::Button("Play")) {
+        audio->Play(false);
+    }
+    if (ImGui::Button("Stop")) {
+        audio->Stop();
+    }
+    if (ImGui::Button("Pause")) {
+        audio->Pause();
+    }
+    if (ImGui::Button("Resume")) {
+        audio->Resume();
+    }
+    //volume
+    static float volume = 0.1f;
+    ImGui::SliderFloat("Volume", &volume, 0.0f, 1.0f);
+    audio->SetVolume(volume);
 
-	// 再生バー
-	static float playbackPosition = 0.0f;
-	//再生位置の取得
-	playbackPosition = audio->GetPlaybackPosition();
-	//再生位置の視認
-	ImGui::SliderFloat("Playback Position", &playbackPosition, 0.0f, duration);
-	//audio->SetPlaybackPosition(playbackPosition);
+    // 再生バー
+    static float playbackPosition = 0.0f;
+    //再生位置の取得
+    playbackPosition = audio->GetPlaybackPosition();
+    //再生位置の視認
+    ImGui::SliderFloat("Playback Position", &playbackPosition, 0.0f, duration);
+    //audio->SetPlaybackPosition(playbackPosition);
 
-	//speed
-	static float speed = 1.0f;
-	ImGui::SliderFloat("Speed", &speed, 0.0f, 2.0f);
-	audio->SetPlaybackSpeed(speed);
+    //speed
+    static float speed = 1.0f;
+    ImGui::SliderFloat("Speed", &speed, 0.0f, 2.0f);
+    audio->SetPlaybackSpeed(speed);
 
-	ImGui::End();
-
+    ImGui::End();
 
 #endif // DEBUG
 

--- a/project/imgui.ini
+++ b/project/imgui.ini
@@ -14,19 +14,19 @@ Size=500,400
 Collapsed=0
 
 [Window][Sprite]
-Pos=682,88
-Size=500,100
-Collapsed=0
+Pos=662,55
+Size=500,241
+Collapsed=1
 
 [Window][Object3D]
 Pos=32,323
 Size=192,158
-Collapsed=1
+Collapsed=0
 
 [Window][Object3D2]
 Pos=19,375
 Size=309,143
-Collapsed=0
+Collapsed=1
 
 [Window][Scratch Control]
 Pos=178,98


### PR DESCRIPTION
`Object3d.PS.hlsl` の `main` 関数で法線と光の方向のドット積計算を修正し、アルファ値が特定条件を満たす場合にピクセルを破棄するコードを追加しました。 `Model.h`、`Object3d.cpp`、`Object3d.h` に `SetModelColor` と `GetModelColor` メソッドを追加し、モデルの色を設定および取得できるようにしました。 `PSO.cpp` の `CreateGraphicPipeline` 関数にブレンドモードの設定を追加し、複数のブレンドモードに対応できるようにしました。 `PSO.h` にブレンドモードの列挙型と、それを設定および取得するメソッドを追加しました。
`DebugScene.cpp` の `ImGuiDraw` 関数で ImGui ウィンドウのレイアウトを修正し、スプライトとオブジェクトの色を編集できるようにしました。 `imgui.ini` のウィンドウ位置とサイズ、折りたたみ状態を変更しました。

モデルの色設定追加とライティング計算修正

`Object3d.PS.hlsl` の `main` 関数でライティング計算の法線と光の方向のドット積計算を修正し、アルファ値が特定条件を満たす場合にピクセルを破棄するコードを追加しました。 `Model.h` に `SetModelColor` と `GetModelColor` メソッドを追加し、モデルの色を設定および取得できるようにしました。 `Object3d.cpp` と `Object3d.h` の `Object3d` クラスに `SetModelColor` と `GetModelColor` メソッドを追加しました。 `PSO.cpp` の `CreateGraphicPipeline` 関数にブレンドモードの設定を追加し、複数のブレンドモード（通常、加算、減算、乗算、スクリーン）をサポートしました。 `PSO.h` にブレンドモードの列挙型と、それを設定および取得するメソッドを追加しました。
`DebugScene.cpp` の `ImGuiDraw` 関数で ImGui ウィンドウのレイアウトを変更し、スプライトと 3D オブジェクトの色を編集できるようにし、オーディオコントロールの UI を追加しました。 `imgui.ini` のウィンドウ設定を変更し、ウィンドウの位置やサイズ、折りたたみ状態を更新しました。